### PR TITLE
Fix behaviour for held job submission

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BatchEuphoriaJobManager.groovy
@@ -63,6 +63,7 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
     boolean requestCoresIsEnabled
     boolean requestStorageIsEnabled
     boolean passEnvironment
+    boolean holdJobsIsEnabled
 
     BatchEuphoriaJobManager(BEExecutionService executionService, JobManagerOptions parms) {
         assert(executionService)
@@ -88,6 +89,7 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
         this.requestCoresIsEnabled = parms.requestCoresIsEnabled
         this.requestStorageIsEnabled = parms.requestStorageIsEnabled
         this.passEnvironment = parms.passEnvironment
+        this.holdJobsIsEnabled = Optional.ofNullable(parms.holdJobIsEnabled).orElse(getDefaultForHoldJobsEnabled())
 
         if (parms.createDaemon) {
             createUpdateDaemonThread()
@@ -248,10 +250,11 @@ abstract class BatchEuphoriaJobManager<C extends Command> {
         return Collections.unmodifiableList([])
     }
 
+    boolean getDefaultForHoldJobsEnabled() { return true }
 
-    boolean getDefaultForHoldJobsEnabled() { return false }
-
-    boolean isHoldJobsEnabled() { getDefaultForHoldJobsEnabled() }
+    boolean isHoldJobsEnabled() {
+        return holdJobsIsEnabled
+    }
 
     String getUserEmail() {
         return userEmail

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/JobManagerOptions.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/JobManagerOptions.groovy
@@ -59,6 +59,8 @@ class JobManagerOptions {
      */
     boolean passEnvironment
 
+    Boolean holdJobIsEnabled
+
     Map<String, String> additionalOptions
 
     static JobManagerOptionsBuilder create() {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
@@ -49,7 +49,6 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
         String command = "kill -s SIGKILL ${jobIDs*.id.join(" ")}"
         return executionService.execute(command, false)
     }
-
     @Override
     protected ExecutionResult executeStartHeldJobs(List<BEJobID> jobIDs) {
         String command = "kill -s SIGCONT ${jobIDs*.id.join(" ")}"
@@ -58,6 +57,11 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
 
     @Override
     void addToListOfStartedJobs(BEJob job) {}
+
+    @Override
+    boolean getDefaultForHoldJobsEnabled() {
+        return false
+    }
 
     @Override
     String getJobIdVariable() {


### PR DESCRIPTION
Jobs were not submitted on hold by default for LSF. This behaviour
changes with this commit, default for all job managers will be hold jobs
after submission.

The value can now also be set via the JobManagerOptions class.