### PR TITLE
Some fixes for JobManager issues

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/JobState.java
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/JobState.java
@@ -55,7 +55,7 @@ public enum JobState implements Serializable {
     }
 
     public static boolean _isPlannedOrRunning(JobState jobState) {
-        return Arrays.asList(JobState.RUNNING, JobState.QUEUED, JobState.HOLD, JobState.STARTED, JobState.UNSTARTED).contains(jobState);
+        return Arrays.asList(JobState.RUNNING, JobState.QUEUED, JobState.HOLD, JobState.SUSPENDED, JobState.STARTED, JobState.UNSTARTED).contains(jobState);
     }
 
     public boolean isDummy() {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/UpdateDaemonListener.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/UpdateDaemonListener.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (Deutsches Krebsforschungszentrum, DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://github.com/DKFZ-ODCF/COWorkflowsBasePlugin/LICENSE.txt).
+ */
+package de.dkfz.roddy.execution.jobs
+
+import groovy.transform.CompileStatic
+
+/**
+ * Listener interface for ended jobs, if the update daemon is active.
+ * Use JobManager.addUpdateDaemonListener to add a listener.
+ */
+@CompileStatic
+interface UpdateDaemonListener {
+    void jobEnded(BEJob job, JobState state)
+}

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/ClusterJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/ClusterJobManager.groovy
@@ -55,6 +55,11 @@ abstract class ClusterJobManager<C extends Command> extends BatchEuphoriaJobMana
     }
 
     @Override
+    boolean executesWithoutJobSystem() {
+        return true
+    }
+
+    @Override
     ProcessingParameters convertResourceSet(BEJob job, ResourceSet resourceSet) {
         assert resourceSet
 

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
@@ -99,6 +99,9 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
 
     @Override
     BEJobResult submitJob(BEJob job) {
+        if (forbidFurtherJobSubmission) {
+            throw new BEException("You are not allowed to submit further jobs. This happens, when you call waitForJobs().")
+        }
         // Some of the parent jobs are in a bad state!
         Command command = createCommand(job)
         BEJobResult jobResult


### PR DESCRIPTION
_isPlannedOrRunningIn JobState will now also recognize SUSPENDED jobs.
This caused an error in waitForJobs.

BatchEuphoriaJobManager:
- Created the waitForUpdateIntervalDuration() method. This will wait for
  the configured duration (or 10 seconds). Wait is done in increments of
  1 second, so that the loop can be broken, when closeThread is true
- Created the stopUpdateDaemon() method
- Created the isDaemonAlive() method
- Corrected updateActiveJobList and added a bit of info output. Fixed a
  concurrent modification exception.
- Moved waitForJobsToFinish() to the bottom and make it use
  waitForUpdateIntervalDuration()