### PR TITLE
Updated to RoddyToolLib 2.3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ To start the integration tests, please fill in host and user settings (password 
 
 # Change Logs
 
+* 0.0.13
+
+   - Update to RoddyToolLib 2.3.0 (\[Async\]ExecutionResult). Explicitly use stdout instead of `ExecutionResult.resultLines` that could also contain stderr, dependent on execution service.
+
 * 0.0.12
 
    - accounting name added to Job and implementation of `-P` parameter for `bsub` (LSF).

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
     compile group: 'org.apache.commons', name: 'commons-text', version: '1.1'
     compile 'com.google.guava:guava:23.0'
-    compile 'com.github.theroddywms:RoddyToolLib:2.1.1'
+    compile 'com.github.theroddywms:RoddyToolLib:2.3.0'
 }
 
 task writePom {

--- a/src/main/groovy/de/dkfz/roddy/TestExecutionService.groovy
+++ b/src/main/groovy/de/dkfz/roddy/TestExecutionService.groovy
@@ -49,11 +49,6 @@ class TestExecutionService implements BEExecutionService {
     }
 
     @Override
-    ExecutionResult execute(String command, boolean waitForIncompatibleClassChangeError, OutputStream outputStream) {
-        return null
-    }
-
-    @Override
     boolean isAvailable() {
         return true
     }

--- a/src/main/groovy/de/dkfz/roddy/execution/BEExecutionService.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/BEExecutionService.groovy
@@ -21,9 +21,6 @@ interface BEExecutionService {
 
     ExecutionResult execute(String command, boolean waitFor)
 
-    ExecutionResult execute(String command, boolean waitForIncompatibleClassChangeError, OutputStream outputStream)
-
-
     /**
      * Query this to find out, if the service is still active
       */

--- a/src/main/groovy/de/dkfz/roddy/execution/RestExecutionService.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/RestExecutionService.groovy
@@ -181,7 +181,7 @@ class RestExecutionService implements BEExecutionService {
                 }
             }
             this.tokenDate = LocalDateTime.now()
-            return new RestResult(response.getAllHeaders(), result, response.getStatusLine().getStatusCode())
+            return new RestResult(restCommand, response.getAllHeaders(), result, response.getStatusLine().getStatusCode())
         } finally {
             response.close()
         }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/BEJobResult.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/BEJobResult.groovy
@@ -67,7 +67,7 @@ class BEJobResult implements Serializable {
     }
 
     Optional<List<String>> getResultLines() {
-        return Optional.of(executionResult).map { it.resultLines } as Optional<List<String>>
+        return Optional.of(executionResult).map { it.stdout } as Optional<List<String>>
     }
 
     boolean isSuccessful() {

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/GridEngineBasedJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/GridEngineBasedJobManager.groovy
@@ -69,12 +69,12 @@ abstract class GridEngineBasedJobManager<C extends Command> extends ClusterJobMa
             queryCommand << " -u $userIDForQueries "
 
         ExecutionResult er = executionService.execute(queryCommand.toString())
-        List<String> resultLines = er.resultLines
+        List<String> resultLines = er.stdout
 
         Map<BEJobID, JobState> result = [:]
 
         if (!er.successful) {
-            throw new BEException("The execution of ${queryCommand} failed.\n\t" + er.resultLines?.join("\n\t")?.toString())
+            throw new BEException("Execution failed. ${er.toStatusLine()}")
         } else {
             if (resultLines.size() > 2) {
 
@@ -110,9 +110,9 @@ abstract class GridEngineBasedJobManager<C extends Command> extends ClusterJobMa
         ExecutionResult er = executionService.execute(qStatCommand.toString())
 
         if (er != null && er.successful) {
-            queriedExtendedStates = this.processQstatOutputFromXML(er.resultLines.join("\n"))
+            queriedExtendedStates = this.processQstatOutputFromXML(er.stdout.join("\n"))
         } else {
-            throw new BEException("Extended job states couldn't be retrieved. \n Returned status code:${er.exitCode} \n ${qStatCommand.toString()} \n\t result:${er.resultLines.join("\n\t")}")
+            throw new BEException("Extended job states couldn't be retrieved: ${er.toStatusLine()}")
         }
         return queriedExtendedStates
     }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManager.groovy
@@ -173,10 +173,10 @@ class LSFJobManager extends AbstractLSFJobManager {
         }
 
         ExecutionResult er = executionService.execute(queryCommand.toString())
-        List<String> resultLines = er.resultLines
+        List<String> resultLines = er.stdout
 
         if (!er.successful) {
-            String error = "Job status couldn't be updated. \n command: ${queryCommand} \n status code: ${er.exitCode} \n result: ${er.resultLines}"
+            String error = "Job status couldn't be updated. \n command: ${er.toStatusLine()}"
             throw new BEException(error)
         }
 
@@ -335,7 +335,7 @@ class LSFJobManager extends AbstractLSFJobManager {
     private File getBjobsFile(String path, BEJobID jobID, String fileTypeSuffix) {
         if (!path) {
             return null
-        } else if (executionService.execute("LC_ALL=C stat -c %F ${BashUtils.strongQuote(path)} 2> /dev/null").firstLine == "directory") {
+        } else if (executionService.execute("LC_ALL=C stat -c %F ${BashUtils.strongQuote(path)} 2> /dev/null").firstStdoutLine == "directory") {
             return new File(path, "${jobID.getId()}.${fileTypeSuffix}")
         } else {
             return new File(path)

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/RestResult.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/RestResult.groovy
@@ -27,8 +27,8 @@ class RestResult extends ExecutionResult {
      * @param body - body of the respond
      * @param statusCode - http status code
      */
-    RestResult(Header[] headers, String body, int statusCode) {
-        super(statusCode == 200, statusCode, [body], null)
+    RestResult(RestSubmissionCommand command, Header[] headers, String body, int statusCode) {
+        super(commandSummaryList(command), statusCode == 200, statusCode, [body], [], null)
         this.headers = headers
     }
 
@@ -42,7 +42,20 @@ class RestResult extends ExecutionResult {
     }
 
     String getBody() {
-        resultLines.join("\n")
+        stdout.join("\n")
     }
+
+    private static List<String> commandSummaryList(RestSubmissionCommand command) {
+        List<String> summary =
+                ["resource=$command.resource",
+                 "method=$command.httpMethod",
+                 "headers=[" +
+                         command.requestHeaders.collect {
+                             "${it.name}=${it.value}"
+                         }.join(", ") + "]",
+                 "body=$command.requestBody"] as List<String>
+        return summary
+    }
+
 
 }

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/RestSubmissionCommand.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/rest/RestSubmissionCommand.groovy
@@ -9,7 +9,6 @@ package de.dkfz.roddy.execution.jobs.cluster.lsf.rest
 import de.dkfz.roddy.config.JobLog
 import de.dkfz.roddy.execution.jobs.BEJobID
 import de.dkfz.roddy.execution.jobs.SubmissionCommand
-import de.dkfz.roddy.execution.jobs.cluster.lsf.LSFJobManager
 import groovy.transform.CompileStatic
 import org.apache.http.Header
 import sun.reflect.generics.reflectiveObjects.NotImplementedException

--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/direct/synchronousexecution/DirectSynchronousExecutionJobManager.groovy
@@ -121,7 +121,7 @@ class DirectSynchronousExecutionJobManager extends BatchEuphoriaJobManager<Direc
             command.setJobID(jobID)
             res = executionService.execute(command)
             if (!res.successful)
-                throw new BEException("Execution of Job ${jobID} failed with exit code ${res.exitCode} and message ${res.resultLines}")
+                throw new BEException("Execution of Job ${jobID} failed: ${res.toStatusLine()}")
         }
 
         jobResult = new BEJobResult(command, job, res, job.tool, job.parameters, job.parentJobs as List<BEJob>)

--- a/src/test/groovy/de/dkfz/roddy/execution/jobs/TestHelper.groovy
+++ b/src/test/groovy/de/dkfz/roddy/execution/jobs/TestHelper.groovy
@@ -28,11 +28,6 @@ class TestHelper {
             }
 
             @Override
-            ExecutionResult execute(String command, boolean waitForIncompatibleClassChangeError, OutputStream outputStream) {
-                return null
-            }
-
-            @Override
             boolean isAvailable() {
                 return false
             }

--- a/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/AbstractLSFJobManagerSpec.groovy
+++ b/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/AbstractLSFJobManagerSpec.groovy
@@ -37,11 +37,6 @@ class AbstractLSFJobManagerSpec extends Specification {
             }
 
             @Override
-            ExecutionResult execute(String command, boolean waitForIncompatibleClassChangeError, OutputStream outputStream) {
-                return null
-            }
-
-            @Override
             boolean isAvailable() {
                 return false
             }

--- a/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManagerSpec.groovy
+++ b/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManagerSpec.groovy
@@ -303,15 +303,19 @@ class LSFJobManagerSpec extends Specification {
 
     void "test queryExtendedJobStateById"() {
         given:
-        JobManagerOptions parms = JobManagerOptions.create().setMaxTrackingTimeForFinishedJobs(Duration.ofDays(360000)).build()
+        JobManagerOptions parms = JobManagerOptions.create().
+                setMaxTrackingTimeForFinishedJobs(Duration.ofDays(360000)).build()
         def jsonFile = getResourceFile("queryExtendedJobStateByIdTest.json")
         BEExecutionService testExecutionService = [
-                execute: { String s -> new ExecutionResult(true, 0, jsonFile.readLines(), null) }
+                execute: { String s ->
+                    new ExecutionResult(["executed/command"], true, 0, jsonFile.readLines(), [])
+                }
         ] as BEExecutionService
         LSFJobManager manager = new LSFJobManager(testExecutionService, parms)
 
         when:
-        Map<BEJobID, GenericJobInfo> result = manager.queryExtendedJobStateById([new BEJobID("22005")])
+        Map<BEJobID, GenericJobInfo> result =
+                manager.queryExtendedJobStateById([new BEJobID("22005")])
 
         then:
         result.size() == 1

--- a/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommandParserTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/pbs/PBSCommandParserTest.groovy
@@ -49,11 +49,6 @@ class PBSCommandParserTest {
             }
 
             @Override
-            ExecutionResult execute(String command, boolean waitForIncompatibleClassChangeError, OutputStream outputStream) {
-                return null
-            }
-
-            @Override
             boolean isAvailable() {
                 return false
             }


### PR DESCRIPTION
Before resultLines were either stdout only or stdout + stderr, dependent on the executor. Now use explicitly only stdout, where ExecutionResult.resultLines was used before.

CI will only work if the RoddyToolLib PR is accepted and the 2.3.0 version was relaesed.