### PR TITLE
Recent LSF update broke bjobs command behavior

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManager.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManager.groovy
@@ -35,8 +35,8 @@ class LSFJobManager extends AbstractLSFJobManager {
 
     final static String TIMESTAMP_PATTERN = /${MONTH}\s+${DAY}\s+${TIME}(\s+${YEAR})?(\s+${LSF_SUFFIX})?/
 
-    private static final String LSF_COMMAND_QUERY_STATES = "bjobs -a -o -hms -json \"jobid job_name stat finish_time\""
-    private static final String LSF_COMMAND_QUERY_EXTENDED_STATES = "bjobs -a -o -hms -json \"jobid job_name stat user queue " +
+    private static final String LSF_COMMAND_QUERY_STATES = "bjobs -a -hms -json -o \"jobid job_name stat finish_time\""
+    private static final String LSF_COMMAND_QUERY_EXTENDED_STATES = "bjobs -a -hms -json -o \"jobid job_name stat user queue " +
             "job_description proj_name job_group job_priority pids exit_code from_host exec_host submit_time start_time " +
             "finish_time cpu_used run_time user_group swap max_mem runtimelimit sub_cwd " +
             "pend_reason exec_cwd output_file input_file effective_resreq exec_home slots error_file command dependency \""

--- a/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManagerSpec.groovy
+++ b/src/test/groovy/de/dkfz/roddy/execution/jobs/cluster/lsf/LSFJobManagerSpec.groovy
@@ -284,9 +284,9 @@ class LSFJobManagerSpec extends Specification {
 
         where:
         month | day  | hour | minute | second | year   | suffix | expectedYear | referenceDate
-        "Jan" | "01" | "01" | "02"   | ""     | ""     | ""     | 2021         | ZonedDateTime.of(2021, 1, 29, 19, 56, 0, 0, ZoneId.systemDefault())
-        "Feb" | "02" | "01" | "02"   | ""     | ""     | "L"    | 2021         | ZonedDateTime.of(2021, 1, 29, 19, 56, 0, 0, ZoneId.systemDefault())
-        "Feb" | "02" | "01" | "02"   | ""     | ""     | "L"    | 2021         | ZonedDateTime.of(2021, 2,  3, 19, 56, 0, 0, ZoneId.systemDefault())
+        "Jan" | "01" | "01" | "02"   | ""     | ""     | ""     | 2022         | ZonedDateTime.of(2022, 1, 29, 19, 56, 0, 0, ZoneId.systemDefault())
+        "Feb" | "02" | "01" | "02"   | ""     | ""     | "L"    | 2022         | ZonedDateTime.of(2022, 1, 29, 19, 56, 0, 0, ZoneId.systemDefault())
+        "Feb" | "02" | "01" | "02"   | ""     | ""     | "L"    | 2022         | ZonedDateTime.of(2022, 2,  3, 19, 56, 0, 0, ZoneId.systemDefault())
         "Mar" | "03" | "01" | "02"   | ""     | "1000" | ""     | 1000         | ZonedDateTime.of(2021, 1, 29, 19, 56, 0, 0, ZoneId.systemDefault())
         "Apr" | "04" | "01" | "02"   | ""     | "1001" | "L"    | 1001         | ZonedDateTime.of(2021, 1, 29, 19, 56, 0, 0, ZoneId.systemDefault())
         "May" | "5"  | "01" | "02"   | "03"   | "1002" | ""     | 1002         | ZonedDateTime.of(2021, 1, 29, 19, 56, 0, 0, ZoneId.systemDefault())


### PR DESCRIPTION
The position of -o option relative to field names is now stricter.